### PR TITLE
Fixed creation of closed field blocks. 

### DIFF
--- a/iktomi/cms/templates/widgets/collapsable_block.html
+++ b/iktomi/cms/templates/widgets/collapsable_block.html
@@ -1,4 +1,6 @@
-<div class="border form text init-block {{ widget.classname }}" data-block-name="collapsable-block">
+<div class="border form text init-block {{ widget.classname }}
+            {%- if field.closed %} closed{% endif %}"
+            data-block-name="collapsable-block">
   {%- if field.hint -%}
     <div class="hint hint-right">{{ field.hint }}</div>
   {%- endif -%}


### PR DESCRIPTION
Now they should be created with kwarg 'closed=True'. Example:

FieldBlock('name', fields=[
               Field1,
               FIeld2,
               Field3,
           ], closed=True)
