### PR TITLE
Fixed collapsable block. 

### DIFF
--- a/iktomi/cms/static/js/collapsable_block.js
+++ b/iktomi/cms/static/js/collapsable_block.js
@@ -2,7 +2,7 @@ var CollapsableForm = new Class({
   initialize: function(block){
     //var has_errors = block.getParent('form').getElement('.error');
 
-    block.getChildren('h2').addEvent('mousedown', function(e){
+    block.getElement('h2').addEvent('mousedown', function(e){
       e.stopPropagation(); e.preventDefault();
       block.toggleClass('closed');
     });


### PR DESCRIPTION
getChildren() doesn't work properly if h2 element is nested.
getElement() works good.
