### PR TITLE
fix popup stream's select-all and deselect-all buttons

### DIFF
--- a/iktomi/cms/static/js/popup_stream_select.js
+++ b/iktomi/cms/static/js/popup_stream_select.js
@@ -199,7 +199,7 @@ var PopupStreamSelect = new Class({
                                          'class':'button'});
 
     selectButton.addEvent('click', function(e) {
-        this.popup.contentEl.getElements('.item').each(function(item) {
+        this.popup.contentEl.getElements('.stream-items .item').each(function(item) {
             var id = item.getElement('a').getProperty('rel').match(/^id:(.*)+/)[1];
             if (this._selected_items.indexOf(id) == -1) {
                 this.add(item, id);
@@ -208,7 +208,7 @@ var PopupStreamSelect = new Class({
     }.bind(this));
 
     deselectButton.addEvent('click', function(e) {
-        this.popup.contentEl.getElements('.item').each(function(item) {
+        this.popup.contentEl.getElements('.stream-items .item').each(function(item) {
             var id = item.getElement('a').getProperty('rel').match(/^id:(.*)+/)[1];
             if (this._selected_items.indexOf(id) != -1) {
                 this.remove(id);


### PR DESCRIPTION
Сценарий ошибки следующий. Открывается ItemForm, среди полей формы имеется PopupStreamSelectMultiple (назовем его "A"). Открываем его для выбора - отображается список item'ов потока. Справа от списка - FilterForm. В FilterForm имеется еще один, вложенный PopupStreamSelect (назовем его "B"). Если мы выберем один или несколько item'ов для PopupStreamSelect "B", отвильтруем список по ним, а затем нажмем "Выбрать все" для PopupStreamSelect "A", то в список выбранных item'ов "А" попадут не только значения из списка, но также и значения из FilterForm.
