### PR TITLE
Fixed width of columns in edit_log

### DIFF
--- a/iktomi/cms/static/css/edit_log.css
+++ b/iktomi/cms/static/css/edit_log.css
@@ -18,9 +18,11 @@
     padding: 10px;
     }
 td.edit-log-del{
+    width: 45%;
     background: #fee;
     }
 td.edit-log-ins{
+    width: 45%;
     background: #efe;
     }
 


### PR DESCRIPTION
After attaching media to new document, tables in log are skewed.
