### PR TITLE
option use_list_form_with_filters added to Stream

### DIFF
--- a/iktomi/cms/stream.py
+++ b/iktomi/cms/stream.py
@@ -152,8 +152,7 @@ class Stream(object):
 
     lock_back_title = None
     lock_back_help = None
-    use_list_form_with_filters = False
-    
+
     def __init__(self, module_name, config):
         self.config = config
         self.module_name = module_name

--- a/iktomi/cms/stream_handlers.py
+++ b/iktomi/cms/stream_handlers.py
@@ -154,7 +154,7 @@ class StreamListHandler(StreamAction):
     def list_form_data(self, env, paginator, filter_data):
         use_list_form = self.stream.ListItemForm and \
                 self.stream.list_edit_action.save_allowed(env)
-        if not self.stream.use_list_form_with_filters:
+        if use_list_form and not self.stream.ListItemForm.use_with_filters:
             use_list_form = use_list_form and not filter_data
         
         if use_list_form:

--- a/iktomi/cms/stream_sortables.py
+++ b/iktomi/cms/stream_sortables.py
@@ -23,6 +23,7 @@ class ListItemForm(Form):
 
     ordering_field = 'order'
     template = 'stream_sortables.html'
+    use_with_filters = False
 
     def __init__(self, *args, **kwargs):
         self.ordering_field = kwargs.pop('ordering_field', self.ordering_field)


### PR DESCRIPTION
By default, if filters are enabled for stream its list_form_data is not available 
The ListItemForm option which allows to use list_form_data with filter data
