### PR TITLE
Hide SplitDateTimeField buttons (today, time-select) if field is readonly

### DIFF
--- a/iktomi/cms/static/js/time.js
+++ b/iktomi/cms/static/js/time.js
@@ -120,7 +120,7 @@
     };
 
     Blocks.register('datetime', function (el) {
-        return !el.get('readonly') && Time(el, {container: $('app-content')});
+        return (!el.get('readonly') && !el.dataset.readonly) && Time(el, {container: $('app-content')});
     });
 })();
 

--- a/iktomi/cms/static/js/time.js
+++ b/iktomi/cms/static/js/time.js
@@ -120,7 +120,7 @@
     };
 
     Blocks.register('datetime', function (el) {
-        return (!el.get('readonly') && !el.dataset.readonly) && Time(el, {container: $('app-content')});
+        return !el.dataset.readonly && Time(el, {container: $('app-content')});
     });
 })();
 

--- a/iktomi/cms/templates/stream_row.html
+++ b/iktomi/cms/templates/stream_row.html
@@ -31,7 +31,7 @@
       {%- if item.state == item.ABSENT %} absent{% endif %}
     {%- endif %}"
   {%- endblock %}
-  {%- if item.title is defined %} data-title="{{ item.title }}"{% endif %}>
+  {%- if item.title is defined %} data-title="{{ item.title|striptags }}"{% endif %}>
 
   {%- block list_fields %}
     {%- for name, field in list_fields.items() %}

--- a/iktomi/cms/templates/widgets/fieldset-line.html
+++ b/iktomi/cms/templates/widgets/fieldset-line.html
@@ -1,5 +1,6 @@
 <table class="fieldset fieldset-line{% if field.widget.js_block %} init-block{% endif %}" 
-    {%- if field.widget.js_block %} data-block-name="{{ field.widget.js_block }}"{% endif %}>
+    {%- if field.widget.js_block %} data-block-name="{{ field.widget.js_block }}"{% endif %}
+    {%- if readonly %} data-readonly="readonly"{% endif %}>
   <tr class="error-row">
     {%- for subfield in field.fields %}
       {%- if subfield.readable %}


### PR DESCRIPTION
"Today" and "Time select" buttons of SplitDateTime widget are displayed when field is readonly (e.g. on front version item form)