### PR TITLE
Resize stream select popup after content was loaded

### DIFF
--- a/iktomi/cms/static/js/widgets/popup_stream_select.js
+++ b/iktomi/cms/static/js/widgets/popup_stream_select.js
@@ -137,6 +137,7 @@ var PopupStreamSelect = new Class({
       }.bind(this));
     }
     this.popup.contentEl.addEvent('load', this.patchItemForm.bind(this));
+    this.popup.contentEl.addEvent('load', this.popup.onWindowResize.bind(this.popup));
 
     this.popup.contentEl.addEvent('click', function(e){
         var a = e.target.match('a[data-id]') ?


### PR DESCRIPTION


When we create and save new item with Popup stream select, widget renders list view for a moment. It does not resize itself after ItemForm is loaded again and keeps sizes of list view.
![2015-05-26 13 50 11](https://cloud.githubusercontent.com/assets/3988332/7810892/b2ebddf4-03ae-11e5-9d02-f24e281d095f.png)

`load` event is fired when content is loaded to popup, so we can easily call resizing of popup on this event.