### PR TITLE
Fix incorrect item removal in multiple popup stream select.

### DIFF
--- a/iktomi/cms/static/js/widgets/popup_stream_select.js
+++ b/iktomi/cms/static/js/widgets/popup_stream_select.js
@@ -555,7 +555,8 @@ var PopupStreamSelectMultiple = new Class({
       input.destroy();
       this._rows[index].destroy();
       this._inputs.splice(index, 1);
-      this._selected_items.splice(index, 1);
+      _sel_item_index = this._selected_items.indexOf(input.value)
+      this._selected_items.splice(_sel_item_index, 1);
       this._rows.splice(index, 1);
       this.onChange();
     }).bind(this);


### PR DESCRIPTION
When user change order of items, remove from _selected_items creates a collision between items selected in popup and items in item form.