### PR TITLE
Fix filter form breaking.

### DIFF
--- a/iktomi/cms/static/js/filter_form.js
+++ b/iktomi/cms/static/js/filter_form.js
@@ -83,6 +83,7 @@
           }
           this.setFilters();
 
+          document.activeElement.blur();
         }.bind(this)
       }).get();
     },


### PR DESCRIPTION
When user submit filter form, form hides, and if user continue input – form breaks.
![2015-06-05 17 48 02](https://cloud.githubusercontent.com/assets/5105340/8008521/646abede-0bab-11e5-8721-a56bf3a8fe3b.png)
