### PR TITLE
fixed undefined in time field, while using firefox.

### DIFF
--- a/iktomi/cms/static/js/time.js
+++ b/iktomi/cms/static/js/time.js
@@ -90,7 +90,7 @@
                 visibility: 'hidden'
             },
             click: function(e) {
-                timeField.value = e.target.innerText;
+                timeField.value = (e.target.innerText) ? e.target.innerText : e.target.textContent;
                 widget.setStyle('visibility', 'hidden');
                 document.body.removeEvent('mousedown', close);
             }


### PR DESCRIPTION
![2015-10-07 14 12 29](https://cloud.githubusercontent.com/assets/5105340/10335930/823618d8-6cfd-11e5-824b-b2b4d998f9ba.png)
since firefox don't support innerText, we could use textContent while recive undefined.
