### PR TITLE
Force page reload in item lock handler

### DIFF
--- a/iktomi/cms/static/js/item_lock.js
+++ b/iktomi/cms/static/js/item_lock.js
@@ -176,7 +176,7 @@ ItemLock.prototype = {
         });
         this.popup.hide();
       } else {
-        window.location.reload(); // XXX should work without reload
+        window.location.reload(true); // XXX should work without reload
       }
     } else if(response.status == 'fail'){
       this.stop();


### PR DESCRIPTION
> By default, the reload() method reloads the page from the cache, but you can force it to reload the page from the server by setting the forceGet parameter to true: location.reload(true).

Firefox does not use item form data from server, it can lead to very dangerous effects.