### PR TITLE
Fix error with truncated images

### DIFF
--- a/iktomi/cms/forms/files.py
+++ b/iktomi/cms/forms/files.py
@@ -180,10 +180,10 @@ class AjaxImageField(AjaxFileField):
             resizer = ResizeFit()
             try:
                 img = Image.open(self.clean_value.path)
+                img = resizer(img, (100, 100))
             except IOError:
                 pass
             else:
-                img = resizer(img, (100, 100))
                 img = img.convert('RGB')
                 img_file = StringIO()
                 img.save(img_file, format='jpeg')


### PR DESCRIPTION
Обнаружилась проблема. Существуют такие jpg, которые нормально открываются через `Image.open`, но падают с `IOError: image file is truncated` при попытке ресайза. Вот пример такого файла:
![truncated-image](https://user-images.githubusercontent.com/3988332/75540158-8da9d580-5a2c-11ea-8776-7ac6285d2310.jpg)
